### PR TITLE
[MOD-165][Improvement] Make heading subtitle optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 
 * yield `placeholder.heading`
   * Boolean `img` (default: false)
+  * Boolean `subtitle` (default: true)
 
 
 * yield `placeholder.text`

--- a/addon/components/content-placeholders-heading.js
+++ b/addon/components/content-placeholders-heading.js
@@ -4,5 +4,6 @@ import layout from '../templates/components/content-placeholders-heading';
 export default ContentPlaceholersBase.extend({
   className: 'ember-content-placeholders-heading',
   classNameBindings: ['className'],
+  subtitle: true,
   layout
 });

--- a/addon/templates/components/content-placeholders-heading.hbs
+++ b/addon/templates/components/content-placeholders-heading.hbs
@@ -3,5 +3,7 @@
 {{/if}}
 <div class="{{className}}__content">
   <div class="{{className}}__title"></div>
-  <div class="{{className}}__subtitle"></div>
+  {{#if subtitle}}
+    <div class="{{className}}__subtitle"></div>
+  {{/if}}
 </div>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -28,6 +28,7 @@
   <div class="panel">
     {{#content-placeholders as |placeholder|}}
       {{placeholder.icon}}
+      {{placeholder.heading subtitle=false}}
     {{/content-placeholders}}
   </div>
 </div>

--- a/tests/integration/components/content-placeholders-heading-test.js
+++ b/tests/integration/components/content-placeholders-heading-test.js
@@ -11,4 +11,10 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{content-placeholders-heading img=true}}`);
   assert.equal(this.$('[data-test-ember-content-placeholders-heading-img]').length, 1, 'it has an img');
+
+  this.render(hbs`{{content-placeholders-heading subtitle=false}}`);
+  assert.equal(this.$('.ember-content-placeholders-heading__subtitle').length, 0, 'it has no subtitle');
+
+  this.render(hbs`{{content-placeholders-heading}}`);
+  assert.equal(this.$('.ember-content-placeholders-heading__subtitle').length, 1, 'it has a subtitle');
 });


### PR DESCRIPTION
## Purpose
Make the heading subtitle optional.

## Changes
`subtitle` defaults to `true` for backwards compatibility. `{{placeholder.heading subtitle=false}}` to only show the heading line. 