### PR TITLE
Explicitly use this in templates

### DIFF
--- a/addon/templates/components/content-placeholders-heading.hbs
+++ b/addon/templates/components/content-placeholders-heading.hbs
@@ -1,9 +1,9 @@
-{{#if img}}
-  <div class="{{className}}__img" data-test-ember-content-placeholders-heading-img></div>
+{{#if this.img}}
+  <div class="{{this.className}}__img" data-test-ember-content-placeholders-heading-img></div>
 {{/if}}
-<div class="{{className}}__content">
-  <div class="{{className}}__title"></div>
-  {{#if subtitle}}
-    <div class="{{className}}__subtitle"></div>
+<div class="{{this.className}}__content">
+  <div class="{{this.className}}__title"></div>
+  {{#if this.subtitle}}
+    <div class="{{this.className}}__subtitle"></div>
   {{/if}}
 </div>

--- a/addon/templates/components/content-placeholders-icon.hbs
+++ b/addon/templates/components/content-placeholders-icon.hbs
@@ -1,1 +1,1 @@
-<div class="{{className}}__icon"></div>
+<div class="{{this.className}}__icon"></div>

--- a/addon/templates/components/content-placeholders-list.hbs
+++ b/addon/templates/components/content-placeholders-list.hbs
@@ -1,13 +1,13 @@
-{{#if ordered}}
+{{#if this.ordered}}
   <ol>
-    {{#each itemsArray}}
-      <li class="{{className}}__item" data-test-ember-content-placeholders-list-item>&#8203;<div></div></li>
+    {{#each this.itemsArray}}
+      <li class="{{this.className}}__item" data-test-ember-content-placeholders-list-item>&#8203;<div></div></li>
     {{/each}}
   </ol>
 {{else}}
   <ul>
-    {{#each itemsArray}}
-      <li class="{{className}}__item" data-test-ember-content-placeholders-list-item>&#8203;<div></div></li>
+    {{#each this.itemsArray}}
+      <li class="{{this.className}}__item" data-test-ember-content-placeholders-list-item>&#8203;<div></div></li>
     {{/each}}
   </ul>
 {{/if}}

--- a/addon/templates/components/content-placeholders-nav.hbs
+++ b/addon/templates/components/content-placeholders-nav.hbs
@@ -1,6 +1,6 @@
-<div class="{{className}}__logo"></div>
-<div class="{{className}}__content">
-  <div class="{{className}}__item"></div>
-  <div class="{{className}}__item"></div>
-  <div class="{{className}}__item"></div>
+<div class="{{this.className}}__logo"></div>
+<div class="{{this.className}}__content">
+  <div class="{{this.className}}__item"></div>
+  <div class="{{this.className}}__item"></div>
+  <div class="{{this.className}}__item"></div>
 </div>

--- a/addon/templates/components/content-placeholders-text.hbs
+++ b/addon/templates/components/content-placeholders-text.hbs
@@ -1,3 +1,3 @@
-{{#each linesArray}}
-  <div class="{{className}}__line" data-test-ember-content-placeholders-text-line></div>
+{{#each this.linesArray}}
+  <div class="{{this.className}}__line" data-test-ember-content-placeholders-text-line></div>
 {{/each}}

--- a/addon/templates/components/content-placeholders.hbs
+++ b/addon/templates/components/content-placeholders.hbs
@@ -2,45 +2,45 @@
   (hash
     heading=(
       component 'content-placeholders-heading'
-      rounded=rounded
-      animated=animated
-      centered=centered
+      rounded=this.rounded
+      animated=this.animated
+      centered=this.centered
     )
 
     text=(
       component 'content-placeholders-text'
-      rounded=rounded
-      animated=animated
-      centered=centered
+      rounded=this.rounded
+      animated=this.animated
+      centered=this.centered
     )
 
     img=(
       component 'content-placeholders-img'
-      rounded=rounded
-      animated=animated
-      centered=centered
+      rounded=this.rounded
+      animated=this.animated
+      centered=this.centered
     )
 
     nav=(
       component 'content-placeholders-nav'
-      rounded=rounded
-      animated=animated
-      centered=centered
+      rounded=this.rounded
+      animated=this.animated
+      centered=this.centered
     )
 
     icon=(
       component 'content-placeholders-icon'
-      rounded=rounded
-      animated=animated
-      centered=centered
+      rounded=this.rounded
+      animated=this.animated
+      centered=this.centered
     )
 
     list=(
       component 'content-placeholders-list'
-      rounded=rounded
-      animated=animated
-      centered=centered
-      ordered=ordered
+      rounded=this.rounded
+      animated=this.animated
+      centered=this.centered
+      ordered=this.ordered
     )
   )
 }}


### PR DESCRIPTION
### Purpose

This is to try to fix the deprecation this-property-fallback that is affecting this addon.

### Changes

1. Explicitly use `this.` in the templates.